### PR TITLE
Undefined name: from functools import partial

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -78,8 +78,8 @@ def val_coco(threshold=0.5):
         results = []
         image_ids = []
         for idx, (images, annotations) in enumerate(valid_dataloader):
-            images = images.to(device)
-            annotations = annotations.to(device)
+            images = images.to(args.device)
+            annotations = annotations.to(args.device)
             scores, labels, boxes = model(images)
             scores = scores.cpu()
             labels = labels.cpu()

--- a/models/bifpn.py
+++ b/models/bifpn.py
@@ -2,7 +2,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 
-from .conv_module import ConvModule
+from .conv_module import ConvModule, xavier_init
 import torch
 class BIFPN(nn.Module):
     def __init__(self,

--- a/models/retinahead.py
+++ b/models/retinahead.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 import numpy as np
 import torch.nn as nn
 


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/toandaominh1997/EfficientDet.Pytorch on Python 3.8.0

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./eval.py:81:32: F821 undefined name 'device'
            images = images.to(device)
                               ^
./eval.py:82:42: F821 undefined name 'device'
            annotations = annotations.to(device)
                                         ^
./utils/vis_bbox.py:107:26: F821 undefined name 'label_names'
            label_names= label_names
                         ^
./models/bifpn.py:91:17: F821 undefined name 'xavier_init'
                xavier_init(m, distribution='uniform')
                ^
./models/bifpn.py:167:17: F821 undefined name 'xavier_init'
                xavier_init(m, distribution='uniform')
                ^
./models/retinahead.py:8:13: F821 undefined name 'partial'
    pfunc = partial(func, **kwargs) if kwargs else func
            ^
6     F821 undefined name 'device'
6
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.