### PR TITLE
Added opencv to requirements and locked version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ torch
 torchvision
 pytoan
 albumentations
+opencv-python==4.1.2.30


### PR DESCRIPTION
The latest version of opencv >= 4.2 results in the following error when trying to run demo.py with a webcam:

> qt.qpa.plugin: Could not find the Qt platform plugin "cocoa" in ""

Locking opencv to 4.1 resolves this issue.