### PR TITLE
Improve class number calculation for COCO

### DIFF
--- a/datasets/coco.py
+++ b/datasets/coco.py
@@ -120,7 +120,7 @@ class CocoDataset(Dataset):
         return float(image['width']) / float(image['height'])
 
     def num_classes(self):
-        return 80
+        return len(self.coco.getCatIds())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Substitute the previous hard-coded value `80` with a more robust version. 